### PR TITLE
Changes for Bower 0.9.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "AngularJS",
+  "name": "angular",
   "version": "1.0.6",
   "main": "./angular.js",
   "dependencies": {


### PR DESCRIPTION
- rename component.json to bower.json
- change component name to 'angular'

I rename the component name property because bower 0.9.0 installs it in a folder with the value of it. Which means, currently, if you install angular via bower it gets installed in <code>components/AngularJS</code> which breaks things. E.g. if <code>karma.conf.js</code> expects angular under <code>components/angular</code>
