### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,5 +4,6 @@
   "main": "./angular.js",
   "ignore": [],
   "dependencies": {
+    "jquery": ">= 2.1.0"
   }
 }


### PR DESCRIPTION
Angular's bower.json file currently does not list jQuery as a dependency.
