### PR TITLE
chore(npm): Use CommonJS file as package.json main field

### DIFF
--- a/angular-browserify.js
+++ b/angular-browserify.js
@@ -1,0 +1,3 @@
+require('./angular');
+
+module.exports = angular;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "angular",
   "version": "1.3.9-build.3772+sha.aa798f1",
   "description": "HTML enhanced for web apps",
-  "main": "angular.js",
+  "main": "angular-browserify.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
This will allow Browserify users to `require('angular')` without shimming, and will not affect non-Browserify users.

If this is accepted I will be happy to submit similar PRs for the other modules.